### PR TITLE
禁用 TLS 1.3 以解决连接 EOF 报错

### DIFF
--- a/antissh.sh
+++ b/antissh.sh
@@ -1182,9 +1182,9 @@ fi
 # 1. 强制使用系统 DNS (解决解析问题)
 # 2. 关闭 HTTP/2 客户端 (解决 EOF 等问题)
 if [ -n "\${GODEBUG:-}" ]; then
-  export GODEBUG="\$GODEBUG,netdns=cgo,http2client=0"
+  export GODEBUG="\$GODEBUG,netdns=cgo,http2client=0,tls13=0"
 else
-  export GODEBUG="netdns=cgo,http2client=0"
+  export GODEBUG="netdns=cgo,http2client=0,tls13=0"
 fi
 
 # 使用 graftcp 启动备份的原始 Agent 服务


### PR DESCRIPTION
修复了 HTTPS 请求下（如 /api/client/features）出现的 EOF 错误。

```bash
2025-12-11 13:57:29.496 [info] E1211 13:57:29.495715 808032 log.go:354] Get "https://antigravity-unleash.goog/api/client/features": EOF: Get "https://antigravity-unleash.goog/api/client/features": EOF
2025-12-11 13:57:29.496 [info] E1211 13:57:29.496244 808032 log.go:354] Post "https://antigravity-unleash.goog/api/client/register": EOF: Post "https://antigravity-unleash.goog/api/client/register": EOF
```

TLS 1.3 实现在某些透明代理环境下会导致握手中断，导致 log 中显示 EOF 错误。强制降级到 TLS 1.2 可以解决此兼容性问题，使连接恢复正常。